### PR TITLE
Fix typo in WP Stats 141

### DIFF
--- a/Statistics Capstone/WP Stats 141 Code.Rmd
+++ b/Statistics Capstone/WP Stats 141 Code.Rmd
@@ -60,7 +60,7 @@ ggplot(df, aes(x = PLeadership)) +
 ```{r}
 library(ggplot2)
 
-# Plotting a barchat for a GenderCode
+# Plotting a bar chart for a GenderCode
 ggplot(df, aes(x = GenderCode)) +
   geom_bar(fill = "lightblue", color = "black") +
   theme_minimal() +
@@ -103,7 +103,7 @@ ggplot(df, aes(x = `HighestDegree`)) +
 ```{r}
 library(ggplot2)
 
-# Plotting a barchat for a Distribution of Function of Current Role metric
+# Plotting a bar chart for a Distribution of Function of Current Role metric
 ggplot(df, aes(x = `Function of Current Role`)) +
   geom_bar(fill = "lightblue", color = "black") +
   theme_minimal() +


### PR DESCRIPTION
## Summary
- correct 'barchat' typos to 'bar chart' in WP Stats 141 Code.Rmd

## Testing
- `grep -n "bar chart" -n 'Statistics Capstone/WP Stats 141 Code.Rmd'`

------
https://chatgpt.com/codex/tasks/task_e_685e2aa47f0883288d25ebc99127a186