### PR TITLE
Fix missing mode function and dataset saving in Stats 141 Rmd

### DIFF
--- a/Statistics Capstone/WP Stats 141 Code.Rmd
+++ b/Statistics Capstone/WP Stats 141 Code.Rmd
@@ -23,12 +23,18 @@ data[data == "NULL"] <- NA
 threshold <- nrow(data) * 0.50
 df <- data %>% select_if(~sum(!is.na(.)) > threshold)
 
+# Utility function for computing the mode of a vector
+getmode <- function(v) {
+  uniqv <- unique(v)
+  uniqv[which.max(tabulate(match(v, uniqv)))]
+}
+
 # Filling missing values for numerical columns with median and categorical with mode
 df <- df %>%
   mutate_if(is.numeric, ~ifelse(is.na(.), median(., na.rm = TRUE), .)) %>%
   mutate_if(is.factor, ~ifelse(is.na(.), as.character(getmode(.)), .))
 
-write.csv(data, file = "(updated) revised data to share with UCLA.csv")
+write.csv(df, file = "(updated) revised data to share with UCLA.csv")
 ```
 
 ### EDA
@@ -317,7 +323,7 @@ ggplot(top_10_countries, aes(x = reorder(CountryName, Average_Median), y = Avera
 
 ## Ordinal Regression
 
-### Higest Degree
+### Highest Degree
 
 ```{r}
 library(MASS)


### PR DESCRIPTION
## Summary
- add `getmode` utility function in WP Stats 141 Code.Rmd
- save the cleaned dataset (`df`) instead of the raw dataset
- fix typo in heading for Highest Degree section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e28a6866883289137bca6b1906433